### PR TITLE
separate funders from author

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 cleos push action login.eosn link '["author.eosn", "myaccount", "SIG_K1_KjnbJ2m22HtuRW7u7ZLdoCx76aNMiADHJpATGh32uYeJLdSjhdpHA7tmd4pj1Ni3mSr5DPRHHaydpaggrb5RcBg2HDDn7G"]' -p myaccount
 
 # create bounty
-cleos push action work.pomelo createbounty '[author.eosn, bounty1, "USDT"]' -p author.eosn
+cleos push action work.pomelo createbounty '[author.eosn, bounty1, "USDT", null]' -p author.eosn
 
 # fund bounty
 cleos transfer myaccount work.pomelo "100.0000 USDT" "bounty1" --contract tethertether
@@ -98,6 +98,7 @@ $ ./test.sh
 |---------------|-------------------------------|
 | Backend       | Pomelo Backend                |
 | Admin         | Pomelo Admins                 |
+| Author        | Bounty Author                |
 | Funders       | Bounty Funders                |
 | SC            | Smart Contract                |
 

--- a/src/notifiers.cpp
+++ b/src/notifiers.cpp
@@ -37,7 +37,7 @@ void pomelo::deposit_bounty( const name bounty_id, const name from, const extend
     check( is_token_enabled( symcode ), "pomelo::deposit_bounty: [token=" + symcode.to_string() + "] is not supported");
 
     // require EOSN linked login to allow withdrawals
-    check( is_user(bounty.funder_user_id), "pomelo::deposit_bounty: [funder_user_id] must be linked to EOSN Login");
+    check( is_user(bounty.author_user_id), "pomelo::deposit_bounty: [author_user_id] must be linked to EOSN Login");
 
     // calculate fee
     const extended_asset fee = calculate_fee( ext_quantity );

--- a/work.pomelo.hpp
+++ b/work.pomelo.hpp
@@ -121,7 +121,8 @@ public:
      * ## params
      *
      * - `{name} bount_id` - (primary key) bounty ID (ex: "bounty1")
-     * - `{name} funder_user_id` - funder (EOSN Login ID)
+     * - `{name} author_user_id` - author (EOSN Login ID)
+     * - `{map<name, asset>} funders` - funders contributions map (EOSN Login id => amount)
      * - `{extended_asset} amount` - amount of tokens to be released once bounty is completed
      * - `{set<name>} applicant_user_ids` - list of applicants that have applied to bounty
      * - `{set<name>} approved_user_id` - approved account for bounty
@@ -139,7 +140,8 @@ public:
      * ```json
      * {
      *     "bount_id": "bounty1",
-     *     "funder_user_id": "funder.eosn",
+     *     "author_user_id": "author.eosn",
+     *     "funders": {"funder1.eosn": "5.0000 USDT", "funder2.eosn": "5.0000 USDT"}
      *     "amount": {"quantity": "10.0000 USDT", "contract": "tethertether"},
      *     "claimed": "10.0000 USDT",
      *     "applicant_user_ids": ["hunter.eosn"],
@@ -157,7 +159,8 @@ public:
      */
     struct [[eosio::table]] bounties_row {
         name                    bounty_id;
-        name                    funder_user_id;
+        name                    author_user_id;
+        map<name, asset>        funders;
         extended_asset          amount;
         asset                   claimed;
         set<name>               applicant_user_ids;
@@ -292,13 +295,13 @@ public:
     /**
      * ## ACTION `createbounty`
      *
-     * - **authority**: `funder_user_id`
+     * - **authority**: `author_user_id`
      *
      * Create bounty
      *
      * ### params
      *
-     * - `{name} funder_user_id` - funder (EOSN Login ID)
+     * - `{name} author_user_id` - author (EOSN Login ID)
      * - `{name} bount_id` - bounty ID
      * - `{symbol_code} accepted_token` - accepted deposit token (ex: `"EOS"`)
      * - `{optional<name>} bounty_type` - bounty type (default = traditional)
@@ -306,11 +309,11 @@ public:
      * ### Example
      *
      * ```bash
-     * $ cleos push action work.pomelo createbounty '[funder.eosn, bounty1, "USDT", null]' -p funder.eosn
+     * $ cleos push action work.pomelo createbounty '[author.eosn, bounty1, "USDT", null]' -p funder.eosn
      * ```
      */
     [[eosio::action]]
-    void createbounty( const name funder_user_id, const name bounty_id, const symbol_code accepted_token, const optional<name> bounty_type );
+    void createbounty( const name author_user_id, const name bounty_id, const symbol_code accepted_token, const optional<name> bounty_type );
 
     /**
      * ## ACTION `setstate`
@@ -336,7 +339,7 @@ public:
     /**
      * ## ACTION `approve`
      *
-     * - **authority**: `funder_user_id`
+     * - **authority**: bounty `author_user_id`
      *
      * Author select hunter for bounty
      *


### PR DESCRIPTION
In the future funders and author could be different users
Adding `funders` field to `bounties` table to keep track of those funding the bounty
For MVP1 we can enforce funder to be the same as author. In the future we can allow multiple funders.