### PR TITLE
EOS Native & EOS EVM claim/withdraw

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,6 @@
 ### `@author`
 
 ```bash
-# before creating bounty, must link EOS account with EOSN login
-cleos push action login.eosn link '["author.eosn", "myaccount", "SIG_K1_KjnbJ2m22HtuRW7u7ZLdoCx76aNMiADHJpATGh32uYeJLdSjhdpHA7tmd4pj1Ni3mSr5DPRHHaydpaggrb5RcBg2HDDn7G"]' -p myaccount
-
 # create bounty
 cleos push action work.pomelo create '[author.eosn, bounty1, "USDT", null]' -p author.eosn
 
@@ -276,7 +273,7 @@ $ ./test.sh
     "from": "myaccount",
     "to": "work.pomelo",
     "ext_quantity": {"contract": "tethertether", "quantity": "15.0000 USDT"},
-    "fee": "1.0000 EOS",
+    "fee": "1.0000 USDT",
     "memo": "grant:grant1",
     "value": 100.0,
     "trx_id": "3bf31f6c32a8663bf3fdb0993a2bf3784d181dc879545603dca2046f05e0c9e1",
@@ -609,8 +606,9 @@ Process incoming transfer
 - `{name} to` - to EOS account (process only incoming)
 - `{asset} quantity` - quantity received
 - `{string} memo` - transfer memo, i.e. "bounty1,author.eosn"
+
 ### example
 
 ```bash
-$ cleos transfer author work.pomelo "5.0000 EOS" "bounty1,author.eosn" -p author
+$ cleos transfer author work.pomelo "5.0000 USDT" "bounty1,author.eosn" --contract tethertether -p author.eosn
 ```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # 🍈 Pomelo for Work (Bounties) - Antelope Smart Contract
 
+## Chains supported
+
+| id        | chain |
+|-----------|-------|
+| `eos`     | EOS Native
+| `eos.evm` | EOS EVM
+
 ## Security Audits
 
 - N/A
@@ -60,7 +67,6 @@ cleos push action work.pomelo claim '[bounty1]' -p myaccount
 ```bash
 # configure app
 cleos push action work.pomelo setconfig '[ok, 1000, login.eosn, fee.pomelo, [url]]' -p work.pomelo
-cleos push action work.pomelo token '["4,EOS", eosio.token, 10000, 1]' -p work.pomelo
 cleos push action work.pomelo token '["4,USDT", tethertether, 10000, 0]' -p work.pomelo
 
 # disable contract
@@ -192,8 +198,8 @@ $ ./test.sh
 
 ```json
 {
-    "sym": "4,EOS",
-    "contract": "eosio.token",
+    "sym": "4,USDT",
+    "contract": "tethertether",
     "min_amount": 10000,
     "oracle_id": 1
 }
@@ -269,7 +275,7 @@ $ ./test.sh
     "funder_user_id": "funder.eosn",
     "from": "myaccount",
     "to": "work.pomelo",
-    "ext_quantity": {"contract": "eosio.token", "quantity": "15.0000 EOS"},
+    "ext_quantity": {"contract": "tethertether", "quantity": "15.0000 USDT"},
     "fee": "1.0000 EOS",
     "memo": "grant:grant1",
     "value": 100.0,
@@ -312,7 +318,7 @@ Set token as supported asset
 ### example
 
 ```bash
-$ cleos push action work.pomelo token '["4,EOS", "eosio.token", 10000, 1]' -p work.pomelo
+$ cleos push action work.pomelo token '["4,USDT", "tethertether", 10000, 1]' -p work.pomelo
 ```
 
 ## ACTION `deltoken`
@@ -499,19 +505,24 @@ $ cleos push action work.pomelo deny '[bounty1]' -p author.eosn
 
 ## ACTION `withdraw`
 
-- **authority**: `account` (EOS account linked to EOSN Login's bounty author)
+- **authority**: `author_user_id` (EOSN Login)
 
-Author withdraws funds from bounty in "pending" or "closed" state (EOS account linked with EOSN Login)
+Author withdraws funds from bounty in "pending" state
 
 ### params
 
 - `{name} bounty_id` - bounty ID
-- `{name} receiver` - receiver account (must be linked to EOSN Login author account)
+- `{name} chain` - chain name
+- `{name} receiver` - receiver (Antelope account or EVM address)
 
 ### example
 
 ```bash
-$ cleos push action work.pomelo withdraw '[bounty1, myaccount]' -p myaccount
+// withdraw to EOS Native
+$ cleos push action work.pomelo withdraw '[bounty1, eos, "myaccount"]' -p author.eosn
+
+// withdraw to EOS EVM
+$ cleos push action work.pomelo withdraw '[bounty1, eos.evm, "0xaa2F34E41B397aD905e2f48059338522D05CA534"]' -p author.eosn
 ```
 
 ## ACTION `apply`
@@ -568,19 +579,24 @@ $ cleos push action work.pomelo complete '[bounty1]' -p hunter.eosn
 
 ## ACTION `claim`
 
-- **authority**: `account` (EOS account linked with EOSN Login)
+- **authority**: `approved_user_id` (EOSN Login)
 
 Hunter claims bounty funds
 
 ### params
 
 - `{name} bounty_id` - bounty ID
-- `{name} receiver` - receiver account (must be linked to EOSN Login approved applicant)
+- `{name} chain` - chain name
+- `{name} receiver` - receiver (Antelope account or EVM address)
 
 ### example
 
 ```bash
-$ cleos push action work.pomelo claim '[bounty1]' -p myaccount
+// claim to EOS Native
+$ cleos push action work.pomelo claim '[bounty1, eos, "myaccount"]' -p claimer.eosn
+
+// claim to EOS EVM
+$ cleos push action work.pomelo claim '[bounty1, eos.evm, "0xaa2F34E41B397aD905e2f48059338522D05CA534"]' -p claimer.eosn
 ```
 
 ## TRANSFER NOTIFY HANDLER `on_transfer`

--- a/include/oracle.defi/oracle.defi.hpp
+++ b/include/oracle.defi/oracle.defi.hpp
@@ -7,12 +7,14 @@
 
 using namespace eosio;
 
-constexpr extended_symbol value_symbol { symbol{"USDT",4}, "tethertether"_n };
-constexpr name oracle_code = "oracle.defi"_n;
 
 namespace defi {
 
+constexpr extended_symbol VALUE_SYMBOL { symbol{"USDT",4}, "tethertether"_n };
+constexpr name ORACLE_CODE = "oracle.defi"_n;
+
 class [[eosio::contract("oracle.defi")]] oracle : public eosio::contract {
+
 public:
     using contract::contract;
 
@@ -57,10 +59,11 @@ public:
      */
     static double get_value( const extended_asset in, const uint64_t oracle_id )
     {
-        if (in.get_extended_symbol() == value_symbol)
+        if ( in.get_extended_symbol() == VALUE_SYMBOL) {
             return static_cast<double>(in.quantity.amount) / pow(10, in.quantity.symbol.precision());
+        }
 
-        prices prices_tbl( oracle_code, oracle_code.value);
+        prices prices_tbl( ORACLE_CODE, ORACLE_CODE.value);
         const auto row = prices_tbl.get(oracle_id, "defilend: no oracle");
         print("\nUsing ", row.avg_price, " rate");
 

--- a/src/bridge.cpp
+++ b/src/bridge.cpp
@@ -1,0 +1,18 @@
+void pomelo::handle_bridge_transfer( const name chain, const string receiver, const extended_asset value, const string memo )
+{
+    // handle EOS Native transfer
+    if ( chain == "eos"_n) {
+        const name account = utils::parse_name(receiver);
+        check( account.value, "pomelo::handle_bridge_transfer: [receiver] is required" );
+        check( is_account( account ), "pomelo::handle_bridge_transfer: [receiver] account does not exist");
+        transfer(get_self(), account, value, memo );
+
+    // handle EOS EVM transfer
+    } else if (chain == "eos.evm"_n) {
+        transfer(get_self(), "eosio.evm"_n, value, receiver );
+
+    // unsupported chain
+    } else {
+        check( false, "pomelo::handle_bridge_transfer: [chain] not supported" );
+    }
+}

--- a/src/logs.cpp
+++ b/src/logs.cpp
@@ -17,13 +17,13 @@ void pomelo::statelog( const name bounty_id, const name status, const name actio
 }
 
 [[eosio::action]]
-void pomelo::claimlog( const name bounty_id, const name receiver, const extended_asset ext_quantity, asset fee, const name status, const name worker_user_id, const uint32_t days_since_created )
+void pomelo::claimlog( const name bounty_id, const name chain, const string receiver, const extended_asset bounty, const asset fee, const name status, const name approved_user_id, const uint32_t days_since_created )
 {
     require_auth( get_self() );
 }
 
 [[eosio::action]]
-void pomelo::withdrawlog( const name bounty_id, const name status, const name author_user_id, const name receiver, const extended_asset refund )
+void pomelo::withdrawlog( const name bounty_id, const name chain, const string receiver, const extended_asset refund, const name status, const name author_user_id )
 {
     require_auth( get_self() );
 }

--- a/work.pomelo.hpp
+++ b/work.pomelo.hpp
@@ -245,7 +245,7 @@ public:
      *     "from": "myaccount",
      *     "to": "work.pomelo",
      *     "ext_quantity": {"contract": "tethertether", "quantity": "15.0000 USDT"},
-     *     "fee": "1.0000 EOS",
+     *     "fee": "1.0000 USDT",
      *     "memo": "bounty1,funder1.eosn",
      *     "value": 100.0,
      *     "trx_id": "3bf31f6c32a8663bf3fdb0993a2bf3784d181dc879545603dca2046f05e0c9e1",
@@ -664,7 +664,13 @@ public:
      * - `{name} from` - from EOS account (donation sender)
      * - `{name} to` - to EOS account (process only incoming)
      * - `{asset} quantity` - quantity received
-     * - `{string} memo` - transfer memo, i.e. "autho.eosn:123"
+     * - `{string} memo` - transfer memo, i.e. "bounty1,author.eosn"
+     *
+     * ### example
+     *
+     * ```bash
+     * $ cleos transfer author work.pomelo "5.0000 USDT" "bounty1,author.eosn" --contract tethertether -p author.eosn
+     * ```
      */
     [[eosio::on_notify("*::transfer")]]
     void on_transfer( const name from, const name to, const asset quantity, const string memo );

--- a/work.pomelo.hpp
+++ b/work.pomelo.hpp
@@ -103,8 +103,8 @@ public:
      *
      * ```json
      * {
-     *     "sym": "4,EOS",
-     *     "contract": "eosio.token",
+     *     "sym": "4,USDT",
+     *     "contract": "tethertether",
      *     "min_amount": 10000,
      *     "oracle_id": 1
      * }
@@ -119,6 +119,37 @@ public:
         uint64_t primary_key() const { return sym.code().raw(); }
     };
     typedef eosio::multi_index< "tokens"_n, tokens_row> tokens_table;
+
+    /**
+     * ## TABLE `chains`
+     *
+     * ### params
+     *
+     * - `{name} chain` - name of chain
+     * - `{name} bridge` - bridge contract
+     *
+     * ### example
+     *
+     * ```json
+     * [
+     *     {
+     *         "chain": "eos.evm",
+     *         "bridge": "eosio.evm"
+     *     },
+     *     {
+     *         "chain": "eos",
+     *         "bridge": ""
+     *     }
+     * ]
+     * ```
+     */
+    struct [[eosio::table("chains")]] chains_row {
+        name                chain;
+        name                bridge;
+
+        uint64_t primary_key() const { return chain.value; }
+    };
+    typedef eosio::multi_index< "chains"_n, chains_row> chains_table;
 
     /**
      * ## TABLE `bounties`
@@ -213,7 +244,7 @@ public:
      *     "funder_user_id": "funder.eosn"_n,
      *     "from": "myaccount",
      *     "to": "work.pomelo",
-     *     "ext_quantity": {"contract": "eosio.token", "quantity": "15.0000 EOS"},
+     *     "ext_quantity": {"contract": "tethertether", "quantity": "15.0000 USDT"},
      *     "fee": "1.0000 EOS",
      *     "memo": "bounty1,funder1.eosn",
      *     "value": 100.0,
@@ -279,7 +310,7 @@ public:
      * ### example
      *
      * ```bash
-     * $ cleos push action work.pomelo token '["4,EOS", "eosio.token", 10000, 1]' -p work.pomelo
+     * $ cleos push action work.pomelo token '["4,USDT", "tethertether", 10000, 1]' -p work.pomelo
      * ```
      */
     [[eosio::action]]
@@ -531,23 +562,28 @@ public:
     /**
      * ## ACTION `withdraw`
      *
-     * - **authority**: `account` (EOS account linked to EOSN Login's bounty author)
+     * - **authority**: `author_user_id` (EOSN Login)
      *
-     * Author withdraws funds from bounty in "pending" state (EOS account linked with EOSN Login)
+     * Author withdraws funds from bounty in "pending" state
      *
      * ### params
      *
      * - `{name} bounty_id` - bounty ID
-     * - `{name} receiver` - receiver account (must be linked to EOSN Login author account)
+     * - `{name} chain` - chain name
+     * - `{name} receiver` - receiver (Antelope account or EVM address)
      *
      * ### example
      *
      * ```bash
-     * $ cleos push action work.pomelo withdraw '[bounty1, myaccount]' -p myaccount
+     * // withdraw to EOS Native
+     * $ cleos push action work.pomelo withdraw '[bounty1, eos, "myaccount"]' -p author.eosn
+     *
+     * // withdraw to EOS EVM
+     * $ cleos push action work.pomelo withdraw '[bounty1, eos.evm, "0xaa2F34E41B397aD905e2f48059338522D05CA534"]' -p author.eosn
      * ```
      */
     [[eosio::action]]
-    void withdraw( const name bounty_id, const name receiver );
+    void withdraw( const name bounty_id, const name chain, const string receiver );
 
     /**
      * ## ACTION `apply`
@@ -595,23 +631,28 @@ public:
     /**
      * ## ACTION `claim`
      *
-     * - **authority**: `account` (EOS account linked with EOSN Login)
+     * - **authority**: `approved_user_id` (EOSN Login)
      *
      * Hunter claims bounty funds
      *
      * ### params
      *
      * - `{name} bounty_id` - bounty ID
-     * - `{name} receiver` - receiver account (must be linked to EOSN Login approved applicant)
+     * - `{name} chain` - chain name
+     * - `{name} receiver` - receiver (Antelope account or EVM address)
      *
      * ### example
      *
      * ```bash
-     * $ cleos push action work.pomelo claim '[bounty1]' -p myaccount
+     * // claim to EOS Native
+     * $ cleos push action work.pomelo claim '[bounty1, eos, "myaccount"]' -p claimer.eosn
+     *
+     * // claim to EOS EVM
+     * $ cleos push action work.pomelo claim '[bounty1, eos.evm, "0xaa2F34E41B397aD905e2f48059338522D05CA534"]' -p claimer.eosn
      * ```
      */
     [[eosio::action]]
-    void claim( const name bounty_id, const name receiver );
+    void claim( const name bounty_id, const name chain, const string receiver );
 
     /**
      * ## TRANSFER NOTIFY HANDLER `on_transfer`
@@ -628,7 +669,6 @@ public:
     [[eosio::on_notify("*::transfer")]]
     void on_transfer( const name from, const name to, const asset quantity, const string memo );
 
-
     [[eosio::action]]
     void depositlog( const name bounty_id, const name funder_user_id, const name from, const extended_asset ext_quantity, const asset fee, const double value, const string& memo );
 
@@ -639,10 +679,10 @@ public:
     void statelog( const name bounty_id, const name status, const name action );
 
     [[eosio::action]]
-    void claimlog( const name bounty_id, const name receiver, const extended_asset ext_quantity, asset fee, const name status, const name worker_user_id, const uint32_t days_since_created );
+    void claimlog( const name bounty_id, const name chain, const string receiver, const extended_asset bounty, const asset fee, const name status, const name approved_user_id, const uint32_t days_since_created );
 
     [[eosio::action]]
-    void withdrawlog( const name bounty_id, const name status, const name author_user_id, const name receiver, const extended_asset refund );
+    void withdrawlog( const name bounty_id, const name chain, const string receiver, const extended_asset refund, const name status, const name author_user_id );
 
     // DEBUG (used to help testing)
     #ifdef DEBUG
@@ -695,6 +735,9 @@ private:
 
     // utils
     void transfer( const name from, const name to, const extended_asset value, const string memo );
+
+    // bridge
+    void handle_bridge_transfer( const name chain, const string receiver, const extended_asset value, const string memo );
 
     // DEBUG (used to help testing)
     #ifdef DEBUG


### PR DESCRIPTION
FYI: @YaroShkvorets @mellowjayb @SoA432 @fschoell 

## What's new?

- [x] `claim` requires EOSN login
- [x] `withdraw` requires EOSN login
- [x] withdrawing/claiming funds must now provide `chain` & `recipient` (Antelope account or EVM address)
- [x] Support for EOS Native & EOS EVM withdraw transfers


## ACTION `claim`

- **authority**: `approved_user_id` (EOSN Login)

Hunter claims bounty funds

### params

- `{name} bounty_id` - bounty ID
- `{name} chain` - chain name
- `{name} receiver` - receiver (Antelope account or EVM address)

### example

```bash
// claim to EOS Native
$ cleos push action work.pomelo claim '[bounty1, eos, "myaccount"]' -p claimer.eosn

// claim to EOS EVM
$ cleos push action work.pomelo claim '[bounty1, eos.evm, "0xaa2F34E41B397aD905e2f48059338522D05CA534"]' -p claimer.eosn
```

## ACTION `withdraw`

- **authority**: `author_user_id` (EOSN Login)

Author withdraws funds from bounty in "pending" state

### params

- `{name} bounty_id` - bounty ID
- `{name} chain` - chain name
- `{name} receiver` - receiver (Antelope account or EVM address)

### example

```bash
// withdraw to EOS Native
$ cleos push action work.pomelo withdraw '[bounty1, eos, "myaccount"]' -p author.eosn

// withdraw to EOS EVM
$ cleos push action work.pomelo withdraw '[bounty1, eos.evm, "0xaa2F34E41B397aD905e2f48059338522D05CA534"]' -p author.eosn
```